### PR TITLE
fix not being able to build without cache

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -21,7 +21,7 @@ const getCached = () => {
       }
 
       needle.get(`https://${config['netlify-domain']}/catalog.json`, config.needle, (err, resp, body) => {
-        if ((body || [])[0].transportUrl && body[0].transportName && body[0].manifest) {
+        if ((body || []).length && body[0].transportUrl && body[0].transportName && body[0].manifest) {
           console.log('loaded old addon catalog')
           cached.catalog = body
         } else {


### PR DESCRIPTION
as it was before `if ((body || [])[0].transportUrl && body[0].transportName && body[0].manifest)` if body is null or undefined we read [][0] which is undefined and then we try to read .transportUrl of an undefined which is a no go.